### PR TITLE
Added check for if file is null in Play method of PlaySound class

### DIFF
--- a/code/PlaySound.cs
+++ b/code/PlaySound.cs
@@ -36,6 +36,7 @@ namespace minigames
 
         public void Play(float volume)
         {
+            if (file == null) return;
             try
             {
                 file.Position = 0;


### PR DESCRIPTION
Playing sound of reloading first level shotgun was causing [System.NullReferenceException](https://learn.microsoft.com/en-us/dotnet/api/system.nullreferenceexception?view=net-8.0). Now it doesn't.